### PR TITLE
Add endpoint to fetch products grouped by category

### DIFF
--- a/src/main/java/com/example/meat_home/controller/ProductController.java
+++ b/src/main/java/com/example/meat_home/controller/ProductController.java
@@ -1,8 +1,10 @@
 package com.example.meat_home.controller;
 
 import com.example.meat_home.dto.Category.CategoryDto;
+import com.example.meat_home.dto.Category.CategoryProductsDto;
 import com.example.meat_home.dto.Product.CreateProductDto;
 import com.example.meat_home.dto.Product.ProductDto;
+import com.example.meat_home.service.CategoryService;
 import com.example.meat_home.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
@@ -19,7 +21,7 @@ import java.util.List;
 @RequestMapping("/api/products")
 public class ProductController {
     private final ProductService productService;
-
+    private final CategoryService categoryService;
     @GetMapping
     public ResponseEntity<List<ProductDto>> getProducts() {
         return ResponseEntity.ok(productService.getProducts());
@@ -29,6 +31,11 @@ public class ProductController {
     public ResponseEntity<ProductDto> getProductById(@PathVariable Long id) {
         ProductDto product = productService.getProductById(id);
         return product != null ? ResponseEntity.ok(product) : ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/categories")
+    public ResponseEntity<List<CategoryProductsDto>> getProductsWithCategories() {
+        return ResponseEntity.ok(productService.getCategoriesWithProducts());
     }
 
     @PostMapping

--- a/src/main/java/com/example/meat_home/dto/Category/CategoryProductsDto.java
+++ b/src/main/java/com/example/meat_home/dto/Category/CategoryProductsDto.java
@@ -1,0 +1,16 @@
+package com.example.meat_home.dto.Category;
+
+import com.example.meat_home.dto.Product.RawProduct;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryProductsDto {
+    private String name;
+    private List<RawProduct> products;
+}

--- a/src/main/java/com/example/meat_home/dto/Product/RawProduct.java
+++ b/src/main/java/com/example/meat_home/dto/Product/RawProduct.java
@@ -1,0 +1,15 @@
+package com.example.meat_home.dto.Product;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RawProduct {
+    private Long id;
+    private Double price;
+    private String disc;
+    private String name;
+}

--- a/src/main/java/com/example/meat_home/repository/CategoryRepository.java
+++ b/src/main/java/com/example/meat_home/repository/CategoryRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
 }

--- a/src/main/java/com/example/meat_home/service/CategoryService.java
+++ b/src/main/java/com/example/meat_home/service/CategoryService.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final CategoryMapper categoryMapper;
-
     /** Get all categories */
     public List<CategoryDto> getCategories() {
         return categoryRepository.findAll()
@@ -30,6 +29,8 @@ public class CategoryService {
                 .map(categoryMapper::toDto)
                 .orElse(null);
     }
+
+
 
     /** Create a new category */
     public CategoryDto createCategory(CategoryDto dto) {

--- a/src/main/java/com/example/meat_home/service/ProductService.java
+++ b/src/main/java/com/example/meat_home/service/ProductService.java
@@ -1,4 +1,5 @@
 package com.example.meat_home.service;
+import com.example.meat_home.dto.Category.CategoryProductsDto;
 import com.example.meat_home.dto.Product.CreateProductDto;
 import com.example.meat_home.dto.Product.ProductDto;
 import com.example.meat_home.entity.Category;
@@ -32,6 +33,15 @@ public class ProductService {
         return productRepository.findById(id)
                 .map(productMapper::toDto)
                 .orElse(null);
+    }
+    public List<CategoryProductsDto> getCategoriesWithProducts() {
+        List<Category> categories = categoryRepository.findAll();
+        return categories.stream()
+                .map(c -> new CategoryProductsDto(
+                        c.getName(), c.getProducts().stream()
+                        .map(productMapper::toSummaryDto)
+                        .toList()))
+                .toList();
     }
 
     /** Create a new category */

--- a/src/main/java/com/example/meat_home/util/ProductMapper.java
+++ b/src/main/java/com/example/meat_home/util/ProductMapper.java
@@ -1,6 +1,7 @@
 package com.example.meat_home.util;
 
 import com.example.meat_home.dto.Product.ProductDto;
+import com.example.meat_home.dto.Product.RawProduct;
 import com.example.meat_home.entity.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -23,15 +24,14 @@ public class ProductMapper {
         return dto;
     }
 
-    public Product toEntity(ProductDto dto) {
-        if (dto == null) return null;
+    public RawProduct toSummaryDto(Product product) {
+        if (product == null) return null;
 
-        Product prod = new Product();
-        prod.setId(dto.getId());
-        prod.setName(dto.getName());
-        prod.setDisc(dto.getDisc());
-        prod.setPrice(dto.getPrice());
-        prod.setCategory(categoryMapper.toEntity(dto.getCategory()));
-        return prod;
+        RawProduct dto = new RawProduct();
+        dto.setId(product.getId());
+        dto.setName(product.getName());
+        dto.setDisc(product.getDisc());
+        dto.setPrice(product.getPrice());
+        return dto;
     }
 }


### PR DESCRIPTION
Introduced CategoryProductsDto and RawProduct DTOs to represent categories with their products. Added a new /api/products/categories endpoint in ProductController to return products grouped by category, implemented supporting logic in ProductService and ProductMapper.